### PR TITLE
AV-Fixed Incorrect Labels on Ride Form

### DIFF
--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -78,7 +78,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     type="text"
                     isInvalid={Boolean(errors.start)}
                     {...register("start", {
-                        required: "Start time is required.",
+                        required: "Pick up time is required.",
                         pattern: {
                             value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
                             message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."
@@ -107,7 +107,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     type="text"
                     isInvalid={Boolean(errors.start) }
                     {...register("end", {
-                        required: "End time is required.",
+                        required: "Drop off time is required.",
                         pattern: {
                             value: /^(0?[1-9]|1[0-2]):[0-5][0-9](AM|PM)$/,
                             message: "Please enter time in the format HH:MM AM/PM (e.g., 3:30PM)."


### PR DESCRIPTION
There was an improvement done to change these field labels from Start Time and End Time to Pick Up Time and Drop Off Time but the error messages on missing input were not changed

Expected Behavior
Instead of Start Time and End Time, it should be Pick Up Time and Drop Off Time in the error messages.

Current / Observed Behavior
The error messages say Start Time and End Time

Steps to Reproduce
Try to create a ride request
Click the submit button without filling anything in

Updated Behavior:
<img width="1354" alt="Screenshot 2024-05-15 at 10 37 57 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/124840028/36f9e0d6-8f9f-4783-bb99-f3a764f8eec7">

Closes #2 