### PR TITLE
AV-Drivers Controller-Bug

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
@@ -36,7 +36,7 @@ public class DriversController extends ApiController{
     ObjectMapper mapper;
 
     @Operation(summary = "Get a list of all drivers")
-    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/all")
     public ResponseEntity<String> drivers()
             throws JsonProcessingException {
@@ -48,7 +48,7 @@ public class DriversController extends ApiController{
     }
 
     @Operation(summary = "Get user by id")
-    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/get")
     public DriverInfo driver(
             @Parameter(name = "id", description = "Long, id number of user to get", example = "1", required = true) @RequestParam Long id)


### PR DESCRIPTION
Right now any user can get a list of all the drivers and get info on any driver. This is not acceptable.

Expected Behavior
Only admins and drivers should be able to see any relevant info on all the drivers. Users being able to use these endpoints is a significant breach.

Current / Observed Behavior
Right now anyone can go into swagger and use our endpoint to get all of the drivers.

If someone were to use this maliciously in a production setting, it would be disastrous.

Updated Behavior:
Removed access to Normal Users, only Admins and Drivers have access.

<img width="686" alt="Screenshot 2024-05-16 at 5 05 58 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/124840028/60666189-1edf-4e83-83c1-2eb8d9689b24">

P.S. Merge after PR #18!

Closes #10 