### PR TITLE
AV-Updated DriverAvailability Index Backend URL for Drivers

### DIFF
--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
@@ -14,7 +14,7 @@ export default function DriverAvailabilityIndexPage() {
         useBackend(
             // Stryker disable all : hard to test for query caching
             ["/api/driverAvailability"],
-            { method: "GET", url: "/api/driverAvailability/admin/all" },
+            { method: "GET", url: "/api/driverAvailability/" },
             []
             // Stryker restore all 
         );

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityIndexPage.js
@@ -14,7 +14,7 @@ export default function DriverAvailabilityIndexPage() {
         useBackend(
             // Stryker disable all : hard to test for query caching
             ["/api/driverAvailability"],
-            { method: "GET", url: "/api/driverAvailability/" },
+            { method: "GET", url: "/api/driverAvailability" },
             []
             // Stryker restore all 
         );

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityIndexPage.test.js
@@ -45,7 +45,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
 
     test("fetches driverAvailabilities using the correct GET method", async () => {
         setupAdminUser();
-        axiosMock.onGet("/api/driverAvailability/admin/all").reply(config => {
+        axiosMock.onGet("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  // Ensures the method is GET
                 return [200, driverAvailabilityFixtures.threeAvailability];
             }
@@ -76,7 +76,7 @@ describe("DriverAvailabilityIndexPage tests", () => {
         // This variable will help us verify that the correct method was used.
         let wasGetMethodUsed = false;
     
-        axiosMock.onAny("/api/driverAvailability/admin/all").reply(config => {
+        axiosMock.onAny("/api/driverAvailability").reply(config => {
             if (config.method === "get") {  
                 wasGetMethodUsed = true; 
                 return [200, driverAvailabilityFixtures.threeAvailability];


### PR DESCRIPTION
When a user with just a driver role views the driver availability index page from Shifts -> Availability results in a bunch of 404 backend GET error toasts.

Expected Behavior
There should be no toasts, and a driver should be able to view their availabilities.

Steps to Reproduce
As a user with only role driver
Click the Shifts dropdown on the navbar
Click Availability

Fix
Modify DriverAvailabilityIndexPage.js to use the non-admin backend endpoint so that the page works correctly for drivers.

Updated Behavior:
<img width="1352" alt="Screenshot 2024-05-16 at 6 32 26 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/124840028/6fe18e15-7c74-4600-8b28-061688a5a53c">
<img width="1410" alt="Screenshot 2024-05-16 at 6 16 53 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/124840028/37d43ade-b2cb-444d-a65a-6ab7ddb8f7bf">

As seen from the images above. UserId 2 has a Driver Role. When that user views the driver availabilities index page they can see their listed availabilities with no errors occurring.

Closes #3 
