### PR TITLE
XS - BUG: User not logged in can see "Apply to be a Rider" on navbar

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -125,7 +125,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_RIDER") && (
+                !hasRole(currentUser, "ROLE_RIDER") && currentUser.loggedIn && (
                   <Nav.Link id ="appnavbar-applytobearider-link" data-testid="appnavbar-applytoberider" as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }


### PR DESCRIPTION
### Description
Added an additional condition for the 'Apply to be a Rider' navbar item to ensure that users who are not logged in cannot see the tab, preventing a 404 Not Found error.

### Acceptance Criteria

- [ ] A not logged in user does not see any other options on the navbar except the name of the app.

### Preview:
<img width="1440" alt="Screenshot 2024-05-19 at 7 46 33 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/a243cb6c-61df-4b37-80be-831fed063ec4">
<img width="1440" alt="Screenshot 2024-05-19 at 7 47 07 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/625e5426-84d4-441e-8397-e6873c03e9a8">

Closes #1 