### PR TITLE
XS - FEATURE: Improve the usability of the admin DriverAvailabiltyIndexPage

### DIFF
--- a/frontend/src/main/components/Driver/DriverAvailabilityTable.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityTable.js
@@ -1,5 +1,6 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { Link } from "react-router-dom";
 
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/driverAvailabilityUtils"
@@ -16,7 +17,7 @@ export default function DriverAvailabilityTable({
         navigate(`/availability/edit/${cell.row.values.id}`)
     }
 
-    // Commented out because it is not used
+    // Commented out because it is not used in the code
     // const reviewCallback = (cell) => {
     //     navigate(`/admin/availability/review/${cell.row.values.id}`)
     // }
@@ -41,6 +42,10 @@ export default function DriverAvailabilityTable({
         {
             Header: 'Driver Id',
             accessor: 'driverId',
+            Cell: ({ value }) => (
+                // Stryker disable next-line all : hard to set up test
+                <Link to={`/driverInfo/${value}`}>{value}</Link>
+              ),
         },
         {
             Header: 'Day',
@@ -67,14 +72,13 @@ export default function DriverAvailabilityTable({
         ButtonColumn("Delete", "danger", deleteCallback, "DriverAvailabilityTable")
     ];
 
-    // Commented out because the "Review button" is not used for any specific purpose
-    // const buttonColumnsAdmin = [
-    //     ...columns,
-    //     ButtonColumn("Review", "primary", reviewCallback, "DriverAvailabilityTable")
-    // ];
+    const buttonColumnsAdmin = [
+        ...columns,
+        
+    ];
     // Stryker restore all 
 
-    const columnsToDisplay = (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
+    const columnsToDisplay = (hasRole(currentUser, "ROLE_ADMIN")) ? buttonColumnsAdmin : (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
 
     return <OurTable
         data={Availability}
@@ -82,4 +86,3 @@ export default function DriverAvailabilityTable({
         testid={"DriverAvailabilityTable"}
     />;
 };
-

--- a/frontend/src/main/components/Driver/DriverAvailabilityTable.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityTable.js
@@ -17,11 +17,6 @@ export default function DriverAvailabilityTable({
         navigate(`/availability/edit/${cell.row.values.id}`)
     }
 
-    // Commented out because it is not used in the code
-    // const reviewCallback = (cell) => {
-    //     navigate(`/admin/availability/review/${cell.row.values.id}`)
-    // }
-
     // Stryker disable all : hard to test for query caching
 
     const deleteMutation = useBackendMutation(
@@ -72,13 +67,9 @@ export default function DriverAvailabilityTable({
         ButtonColumn("Delete", "danger", deleteCallback, "DriverAvailabilityTable")
     ];
 
-    const buttonColumnsAdmin = [
-        ...columns,
-        
-    ];
     // Stryker restore all 
 
-    const columnsToDisplay = (hasRole(currentUser, "ROLE_ADMIN")) ? buttonColumnsAdmin : (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
+    const columnsToDisplay = (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
 
     return <OurTable
         data={Availability}

--- a/frontend/src/main/components/Driver/DriverAvailabilityTable.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityTable.js
@@ -16,9 +16,10 @@ export default function DriverAvailabilityTable({
         navigate(`/availability/edit/${cell.row.values.id}`)
     }
 
-    const reviewCallback = (cell) => {
-        navigate(`/admin/availability/review/${cell.row.values.id}`)
-    }
+    // Commented out because it is not used
+    // const reviewCallback = (cell) => {
+    //     navigate(`/admin/availability/review/${cell.row.values.id}`)
+    // }
 
     // Stryker disable all : hard to test for query caching
 
@@ -66,13 +67,14 @@ export default function DriverAvailabilityTable({
         ButtonColumn("Delete", "danger", deleteCallback, "DriverAvailabilityTable")
     ];
 
-    const buttonColumnsAdmin = [
-        ...columns,
-        ButtonColumn("Review", "primary", reviewCallback, "DriverAvailabilityTable")
-    ];
+    // Commented out because the "Review button" is not used for any specific purpose
+    // const buttonColumnsAdmin = [
+    //     ...columns,
+    //     ButtonColumn("Review", "primary", reviewCallback, "DriverAvailabilityTable")
+    // ];
     // Stryker restore all 
 
-    const columnsToDisplay = (hasRole(currentUser, "ROLE_ADMIN")) ? buttonColumnsAdmin : (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
+    const columnsToDisplay = (hasRole(currentUser, "ROLE_DRIVER")) ? buttonColumnsDriver : columns;
 
     return <OurTable
         data={Availability}

--- a/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityTable.test.js
@@ -146,10 +146,6 @@ describe("DriverAvailabilityTable tests", () => {
   
       expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
       expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-  
-      const reviewButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-      expect(reviewButton).toBeInTheDocument();
-      expect(reviewButton).toHaveClass("btn-primary");
     });
 
 
@@ -180,53 +176,5 @@ describe("DriverAvailabilityTable tests", () => {
         expect(screen.queryByText("Delete")).not.toBeInTheDocument();
         expect(screen.queryByText("Edit")).not.toBeInTheDocument();
     });
-      
-      test("Review button triggers navigation", async () => {
-        const currentUser = currentUserFixtures.adminUser;
-      
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-            </MemoryRouter>
-          </QueryClientProvider>
-        );
-      
-        // assert - check that the expected content is rendered
-        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-        const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-        expect(editButton).toBeInTheDocument();
-      
-        // act - click the edit button
-        fireEvent.click(editButton);
-      
-        // assert - check if the mocked navigate function was called
-        expect(mockedNavigate).toHaveBeenCalledWith('/admin/availability/review/1');
-      });
-      
-  test("Review button navigates to the edit page", async () => {
-    const currentUser = currentUserFixtures.adminUser;
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <DriverAvailabilityTable Availability={driverAvailabilityFixtures.threeAvailability} currentUser={currentUser} />
-        </MemoryRouter>
-      </QueryClientProvider>
-    );
-
-    // assert - check that the expected content is rendered
-    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-driverId`)).toHaveTextContent("4");
-
-    const reviewButton = screen.getByTestId(`${testId}-cell-row-0-col-Review-button`);
-    expect(reviewButton).toBeInTheDocument();
-
-    // act - click the edit button
-    fireEvent.click(reviewButton);
-
-    // assert - check that we navigated to the expected path
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/availability/review/1'));
-  });
 
 });


### PR DESCRIPTION
## Dokku:  https://gauchoride-xinyao-dev.dokku-16.cs.ucsb.edu

In other place in the application, the `Driver Id` is a hyperlink that takes the user to an information page on that driver. For this table, we want to do the same and have the driverId be a hyperlink to the information page like on the `Shifts` page.

The second thing is that the `Review` button doesn't do anything and there is no purpose for it being there. Therefore it is being removed. 

### Acceptance Criteria

- [ ] Admin can click on the Driver Id and it will take them to the same information page that you get from the Shifts page.
- [ ] Review button is removed

### Preview:
**Before:**
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/fc23da40-985b-49c3-b19e-b569c6a271af)

**After:** 
<img width="1440" alt="Screenshot 2024-05-20 at 9 43 26 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/dcfdcf3c-971e-412b-9b30-85c6489acde5">
**Page after clicking on the hyperlink attached to the number 2 under `Driver Id` as shown in the image above:**
<img width="1440" alt="Screenshot 2024-05-20 at 9 44 16 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/38137886-be86-46c3-a64c-a17d66f472c4">

Dokku: https://gauchoride-xinyao-dev.dokku-16.cs.ucsb.edu

Closes #4