### PR TITLE
XS - EPIC: Improve usability of the DriverAvailabilities Create Page

### DIFF
--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -1,132 +1,142 @@
-import { Button, Form } from 'react-bootstrap';
-import { useForm } from 'react-hook-form'
-import { useNavigate } from 'react-router-dom';
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 
-function DriverAvailabilityForm({ initialContents, submitAction, buttonLabel = "Create" }) {
-    // Stryker disable all
-    const {
-        register,
-        formState: { errors },
-        handleSubmit,
-    } = useForm(
-        { defaultValues: initialContents || {}, }
-    );
-    // Stryker restore all
-    const navigate = useNavigate();
+function DriverAvailabilityForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+  const navigate = useNavigate();
 
-    const testIdPrefix = "DriverAvailabilityForm";
-    return (
-        <Form onSubmit={handleSubmit(submitAction)}>
-            {initialContents && (
-                <Form.Group className="mb-3" >
-                    <Form.Label htmlFor="id">id</Form.Label>
-                    <Form.Control
-                        data-testid={testIdPrefix + "-id"}
-                        id="id"
-                        type="text"
-                        {...register("id")}
-                        value={initialContents.id}
-                        disabled
-                    />
-                </Form.Group>
-            )}
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="driverId">driverId</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-driverId"}
-                    id="driverId"
-                    type="text"
-                    isInvalid={Boolean(errors.driverId)}
-                    {...register("driverId", {
-                        required: "driverId is required.",
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.driverId?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
+  const testIdPrefix = "DriverAvailabilityForm";
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="day">day</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-day"}
-                    id="day"
-                    type="text"
-                    isInvalid={Boolean(errors.day)}
-                    {...register("day", {
-                        required: "day is required."
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.day?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
+  // Stryker disable next-line Regex
+  const time_regex = /^(0?[1-9]|1[0-2]):[0-5][0-9] (AM|PM)$/i;
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="startTime">startTime</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-startTime"}
-                    id="startTime"
-                    type="text"
-                    isInvalid={Boolean(errors.startTime)}
-                    {...register("startTime", {
-                        required: "startTime is required."
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.startTime?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
+  return (
+    <Form
+      onSubmit={handleSubmit((data) => {
+        const { driverId, ...filteredData } = data;
+        submitAction(filteredData);
+      })}
+    >
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">ID</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="endTime">endTime</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-endTime"}
-                    id="endTime"
-                    type="text"
-                    isInvalid={Boolean(errors.endTime)}
-                    {...register("endTime", {
-                        required: "endTime is required."
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.endTime?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="day">Day of the Week</Form.Label>
+        <Form.Select
+          data-testid={testIdPrefix + "-day"}
+          id="day"
+          isInvalid={Boolean(errors.day)}
+          {...register("day", {
+            required: "Day of the Week is required.",
+          })}
+        >
+          <option value="">Select a Day</option>
+          <option value="Monday">Monday</option>
+          <option value="Tuesday">Tuesday</option>
+          <option value="Wednesday">Wednesday</option>
+          <option value="Thursday">Thursday</option>
+          <option value="Friday">Friday</option>
+          <option value="Saturday">Saturday</option>
+          <option value="Sunday">Sunday</option>
+        </Form.Select>
+        <Form.Control.Feedback type="invalid">
+          {errors.day?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="notes">notes</Form.Label>
-                <Form.Control
-                    data-testid={testIdPrefix + "-notes"}
-                    id="notes"
-                    type="text"
-                    isInvalid={Boolean(errors.notes)}
-                    {...register("notes", {
-                        required: "notes is required."
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.notes?.message}
-                </Form.Control.Feedback>
-            </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="startTime">Start Time</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-startTime"}
+          id="startTime"
+          type="text"
+          placeholder="Enter time in the format HH:MM AM/PM (eg. 11:30 AM)"
+          isInvalid={Boolean(errors.startTime)}
+          {...register("startTime", {
+            required: "Start Time is required.",
+            pattern: {
+              value: time_regex,
+              message: "Invalid time format. Use HH:MM AM/PM.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.startTime?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
 
-            <Button
-                type="submit"
-                data-testid={testIdPrefix + "-submit"}
-            >
-                {buttonLabel}
-            </Button>
-            <Button
-                variant="Secondary"
-                onClick={() => navigate(-1)}
-                data-testid={testIdPrefix + "-cancel"}
-            >
-                Cancel
-            </Button>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="endTime">End Time</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-endTime"}
+          id="endTime"
+          type="text"
+          placeholder="Enter time in the format HH:MM AM/PM (eg. 5:30 PM)"
+          isInvalid={Boolean(errors.endTime)}
+          {...register("endTime", {
+            required: "End Time is required.",
+            pattern: {
+              value: time_regex,
+              message: "Invalid time format. Use HH:MM AM/PM.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.endTime?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
 
-        </Form>
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="notes">Notes</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-notes"}
+          id="notes"
+          type="text"
+          placeholder="Include any additional notes here."
+          isInvalid={Boolean(errors.notes)}
+          {...register("notes", {
+            required: "Notes are required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.notes?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
 
-    )
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
 }
 
 export default DriverAvailabilityForm;

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -1,6 +1,6 @@
-import { Button, Form } from "react-bootstrap";
-import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
 
 function DriverAvailabilityForm({
   initialContents,

--- a/frontend/src/main/components/Driver/DriverAvailabilityForm.js
+++ b/frontend/src/main/components/Driver/DriverAvailabilityForm.js
@@ -116,9 +116,7 @@ function DriverAvailabilityForm({
           type="text"
           placeholder="Include any additional notes here."
           isInvalid={Boolean(errors.notes)}
-          {...register("notes", {
-            required: "Notes are required.",
-          })}
+          {...register("notes")}
         />
         <Form.Control.Feedback type="invalid">
           {errors.notes?.message}

--- a/frontend/src/main/pages/Drivers/DriverAvailabilityCreatePage.js
+++ b/frontend/src/main/pages/Drivers/DriverAvailabilityCreatePage.js
@@ -10,7 +10,6 @@ export default function DriverAvailabilityCreatePage() {
         url: "/api/driverAvailability/new",
         method: "POST",
         params: {
-            driverId: availability.driverId,
             day: availability.day,
             startTime: availability.startTime,
             endTime: availability.endTime,

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, act } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import DriverAvailabilityForm from "main/components/Driver/DriverAvailabilityForm"
@@ -16,17 +16,19 @@ jest.mock('react-router-dom', () => ({
 describe("DriverAvailabilityForm tests", () => {
     const queryClient = new QueryClient();
 
-    const expectedHeaders = ["driverId", "day", "startTime", "endTime", "notes"];
+    const expectedHeaders = ["Day of the Week", "Start Time", "End Time", "Notes"];
     const testId = "DriverAvailabilityForm";
 
     test("renders correctly with no initialContents", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <DriverAvailabilityForm />
-                </Router>
-            </QueryClientProvider>
-        );
+        await act(async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <Router>
+                        <DriverAvailabilityForm />
+                    </Router>
+                </QueryClientProvider>
+            );
+        });
 
         expect(await screen.findByText(/Create/)).toBeInTheDocument();
 
@@ -38,13 +40,15 @@ describe("DriverAvailabilityForm tests", () => {
     });
 
     test("renders correctly when passing in initialContents", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <DriverAvailabilityForm initialContents={driverAvailabilityFixtures.oneAvailability} />
-                </Router>
-            </QueryClientProvider>
-        );
+        await act(async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <Router>
+                        <DriverAvailabilityForm initialContents={driverAvailabilityFixtures.oneAvailability} />
+                    </Router>
+                </QueryClientProvider>
+            );
+        });
 
         expect(await screen.findByText(/Create/)).toBeInTheDocument();
 
@@ -54,97 +58,102 @@ describe("DriverAvailabilityForm tests", () => {
         });
 
         expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
-        expect(screen.getByText(`id`)).toBeInTheDocument();
-
-        expect(await screen.findByTestId(`${testId}-driverId`)).toBeInTheDocument();
-        expect(screen.getByText(`driverId`)).toBeInTheDocument();
+        expect(screen.getByText(`ID`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-day`)).toBeInTheDocument();
-        expect(screen.getByText(`day`)).toBeInTheDocument();
+        expect(screen.getByLabelText(`Day of the Week`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-startTime`)).toBeInTheDocument();
-        expect(screen.getByText(`startTime`)).toBeInTheDocument();
+        expect(screen.getByLabelText(`Start Time`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-endTime`)).toBeInTheDocument();
-        expect(screen.getByText(`endTime`)).toBeInTheDocument();
+        expect(screen.getByLabelText(`End Time`)).toBeInTheDocument();
 
         expect(await screen.findByTestId(`${testId}-notes`)).toBeInTheDocument();
-        expect(screen.getByText(`notes`)).toBeInTheDocument();
+        expect(screen.getByLabelText(`Notes`)).toBeInTheDocument();
     });
 
-
     test("that navigate(-1) is called when Cancel is clicked", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <DriverAvailabilityForm />
-                </Router>
-            </QueryClientProvider>
-        );
+        await act(async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <Router>
+                        <DriverAvailabilityForm />
+                    </Router>
+                </QueryClientProvider>
+            );
+        });
+
         expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
         const cancelButton = screen.getByTestId(`${testId}-cancel`);
 
-        fireEvent.click(cancelButton);
+        await act(async () => {
+            fireEvent.click(cancelButton);
+        });
 
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
     });
 
     test("that the correct validations are performed", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <DriverAvailabilityForm />
-                </Router>
-            </QueryClientProvider>
-        );
+        await act(async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <Router>
+                        <DriverAvailabilityForm />
+                    </Router>
+                </QueryClientProvider>
+            );
+        });
 
         expect(await screen.findByText(/Create/)).toBeInTheDocument();
         const submitButton = screen.getByText(/Create/);
-        fireEvent.click(submitButton);
 
-        await screen.findByText(/driverId is required./);
-        expect(screen.getByText(/day is required./)).toBeInTheDocument();
-        expect(screen.getByText(/startTime is required./)).toBeInTheDocument();
-        expect(screen.getByText(/endTime is required./)).toBeInTheDocument();
-        expect(screen.getByText(/notes is required./)).toBeInTheDocument();
+        await act(async () => {
+            fireEvent.click(submitButton);
+        });
 
+        expect(screen.getByText(/Day of the Week is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Start Time is required./)).toBeInTheDocument();
+        expect(screen.getByText(/End Time is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Notes are required./)).toBeInTheDocument();
     });
 
-    test("No Error messsages on good input", async () => {
+    test("No Error messages on good input", async () => {
 
         const mockSubmitAction = jest.fn();
 
+        await act(async () => {
+            render(
+                <Router>
+                    <DriverAvailabilityForm submitAction={mockSubmitAction} />
+                </Router>
+            );
+        });
 
-        render(
-            <Router  >
-                <DriverAvailabilityForm submitAction={mockSubmitAction} />
-            </Router>
-        );
-        await screen.findByTestId("DriverAvailabilityForm-driverId");
+        await screen.findByTestId("DriverAvailabilityForm-day");
 
-        const driverIdField = screen.getByTestId("DriverAvailabilityForm-driverId");
         const dayField = screen.getByTestId("DriverAvailabilityForm-day");
         const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
         const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
         const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
         const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
 
-        fireEvent.change(driverIdField, { target: { value: 'test' } });
-        fireEvent.change(dayField, { target: { value: 'test' } });
-        fireEvent.change(startTimeField, { target: { value: 'test' } });
-        fireEvent.change(endTimeField, { target: { value: 'test' } });
-        fireEvent.change(notesField, { target: { value: 'test' } });
-        fireEvent.click(submitButton);
+        await act(async () => {
+            fireEvent.change(dayField, { target: { value: 'Monday' } });
+            fireEvent.change(startTimeField, { target: { value: '11:00 AM' } });
+            fireEvent.change(endTimeField, { target: { value: '12:00 PM' } });
+            fireEvent.change(notesField, { target: { value: 'Some notes' } });
+        });
+
+        await act(async () => {
+            fireEvent.click(submitButton);
+        });
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
-        expect(screen.queryByText(/driverId is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/day is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/startTime is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/endTime is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/notes is required./)).not.toBeInTheDocument();
-
-
+        expect(screen.queryByText(/Day of the Week is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Start time is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/End time is required./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Notes are required./)).not.toBeInTheDocument();
     });
-
 });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -185,6 +185,11 @@ describe("DriverAvailabilityForm tests", () => {
             fireEvent.click(submitButton);
         });
 
-        expect(screen.getByText(/Invalid time format. Use HH:MM AM\/PM./)).toBeInTheDocument();
+        // There should be 2 error messages for the invalid time format on startTime and endTime
+        const errorMessages = screen.getAllByText(/Invalid time format. Use HH:MM AM\/PM./);
+        expect(errorMessages).toHaveLength(2); 
+
+        expect(screen.getByTestId("DriverAvailabilityForm-startTime")).toHaveClass("is-invalid");
+        expect(screen.getByTestId("DriverAvailabilityForm-endTime")).toHaveClass("is-invalid");
     });
 });

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -115,7 +115,6 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.getByText(/Day of the Week is required./)).toBeInTheDocument();
         expect(screen.getByText(/Start Time is required./)).toBeInTheDocument();
         expect(screen.getByText(/End Time is required./)).toBeInTheDocument();
-        expect(screen.getByText(/Notes are required./)).toBeInTheDocument();
     });
 
     test("No Error messages on good input", async () => {
@@ -154,7 +153,6 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.queryByText(/Day of the Week is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Start time is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/End time is required./)).not.toBeInTheDocument();
-        expect(screen.queryByText(/Notes are required./)).not.toBeInTheDocument();
     });
 
     test("displays error messages for invalid time format", async () => {

--- a/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
+++ b/frontend/src/tests/components/Driver/DriverAvailabilityForm.test.js
@@ -156,4 +156,35 @@ describe("DriverAvailabilityForm tests", () => {
         expect(screen.queryByText(/End time is required./)).not.toBeInTheDocument();
         expect(screen.queryByText(/Notes are required./)).not.toBeInTheDocument();
     });
+
+    test("displays error messages for invalid time format", async () => {
+        await act(async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <Router>
+                        <DriverAvailabilityForm />
+                    </Router>
+                </QueryClientProvider>
+            );
+        });
+
+        const dayField = screen.getByTestId("DriverAvailabilityForm-day");
+        const startTimeField = screen.getByTestId("DriverAvailabilityForm-startTime");
+        const endTimeField = screen.getByTestId("DriverAvailabilityForm-endTime");
+        const notesField = screen.getByTestId("DriverAvailabilityForm-notes");
+        const submitButton = screen.getByTestId("DriverAvailabilityForm-submit");
+
+        await act(async () => {
+            fireEvent.change(dayField, { target: { value: 'Monday' } });
+            fireEvent.change(startTimeField, { target: { value: 'invalid' } });
+            fireEvent.change(endTimeField, { target: { value: 'invalid' } });
+            fireEvent.change(notesField, { target: { value: 'Some notes' } });
+        });
+
+        await act(async () => {
+            fireEvent.click(submitButton);
+        });
+
+        expect(screen.getByText(/Invalid time format. Use HH:MM AM\/PM./)).toBeInTheDocument();
+    });
 });

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityCreatePage.test.js
@@ -57,17 +57,16 @@ describe("DriverAvailabilityCreatePage tests", () => {
         const queryClient = new QueryClient();
         const availability = {
             id: 5,
-            driverId: 3,
             day: "Saturday",
-            startTime: "11:40AM",
-            endTime: "11:59AM",
+            startTime: "11:40 AM",
+            endTime: "11:59 AM",
             notes: "none",
         };
         const noidavailability = {
-            driverId: "3",
+
             day: "Saturday",
-            startTime: "11:40AM",
-            endTime: "11:59AM",
+            startTime: "11:40 AM",
+            endTime: "11:59 AM",
             notes: "none",
         }
 
@@ -81,29 +80,23 @@ describe("DriverAvailabilityCreatePage tests", () => {
             </QueryClientProvider>
         )
 
-
-        const driverIdInput = screen.getByLabelText("driverId")
+        const dayInput = screen.getByLabelText("Day of the Week");
         await waitFor(() => {
-            expect(driverIdInput).toBeInTheDocument();
+            expect(dayInput).toBeInTheDocument();
         });
-
-        const dayInput = screen.getByLabelText("day");
-        expect(dayInput).toBeInTheDocument();
-
-        const startTimeInput = screen.getByLabelText("startTime");
+        const startTimeInput = screen.getByLabelText("Start Time");
         expect(startTimeInput).toBeInTheDocument();
 
-        const endTimeInput = screen.getByLabelText("endTime");
+        const endTimeInput = screen.getByLabelText("End Time");
         expect(endTimeInput).toBeInTheDocument();
 
-        const notesInput = screen.getByLabelText("notes");
+        const notesInput = screen.getByLabelText("Notes");
         expect(notesInput).toBeInTheDocument();
 
         // Simulating filling out the form
         fireEvent.change(dayInput, { target: { value: availability.day } });
         fireEvent.change(startTimeInput, { target: { value: availability.startTime } });
         fireEvent.change(endTimeInput, { target: { value: availability.endTime } });
-        fireEvent.change(driverIdInput, { target: { value: String(availability.driverId) } });
         fireEvent.change(notesInput, { target: { value: String(availability.notes) } });
 
         const createButton = screen.getByRole('button', { name: /Create/ });

--- a/frontend/src/tests/pages/Drivers/DriverAvailabilityEditPage.test.js
+++ b/frontend/src/tests/pages/Drivers/DriverAvailabilityEditPage.test.js
@@ -76,18 +76,16 @@ describe("DriverAvailabilityEditPage tests", () => {
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
             axiosMock.onGet("/api/driverAvailability/id", { params: { id: 17 } }).reply(200, {
                 id: 17,
-                driverId: 2,
                 day: "Tuesday",
-                startTime: "05:00PM",
-                endTime: "07:30PM",
+                startTime: "05:00 PM",
+                endTime: "07:30 PM",
                 notes: "none"
             });
             axiosMock.onPut('/api/driverAvailability').reply(200, {
                 id: 17,
-                driverId: 1,
                 day: "Monday",
-                startTime: "03:30PM",
-                endTime: "04:30PM",
+                startTime: "03:30 PM",
+                endTime: "04:30 PM",
                 notes: "important"
             });
               
@@ -119,13 +117,11 @@ describe("DriverAvailabilityEditPage tests", () => {
             const dayField = getByTestId("DriverAvailabilityForm-day");
             const startTimeField = getByTestId("DriverAvailabilityForm-startTime");
             const endTimeField = getByTestId("DriverAvailabilityForm-endTime");
-            const driverIdField = getByTestId("DriverAvailabilityForm-driverId");
             const notesField = getByTestId("DriverAvailabilityForm-notes");
 
             expect(dayField).toHaveValue("Tuesday");
-            expect(startTimeField).toHaveValue("05:00PM");
-            expect(endTimeField).toHaveValue("07:30PM");
-            expect(driverIdField).toHaveValue("2");
+            expect(startTimeField).toHaveValue("05:00 PM");
+            expect(endTimeField).toHaveValue("07:30 PM");
             expect(notesField).toHaveValue("none");
         });
 
@@ -144,22 +140,19 @@ describe("DriverAvailabilityEditPage tests", () => {
             const dayField = getByTestId("DriverAvailabilityForm-day");
             const startTimeField = getByTestId("DriverAvailabilityForm-startTime");
             const endTimeField = getByTestId("DriverAvailabilityForm-endTime");
-            const driverIdField = getByTestId("DriverAvailabilityForm-driverId");
             const notesField = getByTestId("DriverAvailabilityForm-notes");
 
             expect(dayField).toHaveValue("Tuesday");
-            expect(startTimeField).toHaveValue("05:00PM");
-            expect(endTimeField).toHaveValue("07:30PM");
-            expect(driverIdField).toHaveValue("2");
+            expect(startTimeField).toHaveValue("05:00 PM");
+            expect(endTimeField).toHaveValue("07:30 PM");
             expect(notesField).toHaveValue("none");
             
             const updateButton = screen.getByRole('button', { name: /Update/ });
             expect(updateButton).toBeInTheDocument();
         
             fireEvent.change(dayField, { target: { value: 'Monday' } });
-            fireEvent.change(startTimeField, { target: { value: '03:30PM' } });
-            fireEvent.change(endTimeField, { target: { value: "04:30PM" } });
-            fireEvent.change(driverIdField, { target: { value: 1 } });
+            fireEvent.change(startTimeField, { target: { value: '03:30 PM' } });
+            fireEvent.change(endTimeField, { target: { value: "04:30 PM" } });
             fireEvent.change(notesField, { target: { value: "important" } });
         
             fireEvent.click(updateButton);
@@ -175,10 +168,9 @@ describe("DriverAvailabilityEditPage tests", () => {
 
             expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
             expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
-                driverId: "1",
                 day: "Monday",
-                startTime: "03:30PM",
-                endTime: "04:30PM",
+                startTime: "03:30 PM",
+                endTime: "04:30 PM",
                 notes: "important"
             })); // posted object
         });

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -39,7 +39,7 @@ public class DriverAvailabilityController extends ApiController{
     @PostMapping("/new")
     public DriverAvailability postDriverAvailability(
             @Parameter(name="driverId") @RequestParam long driverId,
-            @Parameter(name="day") @RequestParam String day,
+            @Parameter(name="day") @RequestParam String day, // day of the week
             @Parameter(name="startTime") @RequestParam String startTime,
             @Parameter(name="endTime") @RequestParam String endTime,
             @Parameter(name="notes") @RequestParam String notes)

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityController.java
@@ -38,7 +38,6 @@ public class DriverAvailabilityController extends ApiController{
     @PreAuthorize("hasRole('ROLE_DRIVER')")
     @PostMapping("/new")
     public DriverAvailability postDriverAvailability(
-            @Parameter(name="driverId") @RequestParam long driverId,
             @Parameter(name="day") @RequestParam String day, // day of the week
             @Parameter(name="startTime") @RequestParam String startTime,
             @Parameter(name="endTime") @RequestParam String endTime,
@@ -49,7 +48,7 @@ public class DriverAvailabilityController extends ApiController{
         log.info("notes={}", notes);
 
         DriverAvailability driverAvailability = new DriverAvailability();
-        driverAvailability.setDriverId(driverId);
+        driverAvailability.setDriverId(getCurrentUser().getUser().getId());
         driverAvailability.setDay(day);
         driverAvailability.setStartTime(startTime);
         driverAvailability.setEndTime(endTime);
@@ -82,6 +81,11 @@ public class DriverAvailabilityController extends ApiController{
         DriverAvailability availability;
         availability = driverAvailabilityRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
+
+        if (availability.getDriverId() != getCurrentUser().getUser().getId()) {
+            throw new EntityNotFoundException(DriverAvailability.class, id);
+        }
+
         return availability;
     }
 
@@ -100,7 +104,11 @@ public class DriverAvailabilityController extends ApiController{
         availability = driverAvailabilityRepository.findById(id)
                     .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
 
-        availability.setDriverId(incoming.getDriverId());
+        // ensure that the availability is owned by the current user
+        if (availability.getDriverId() != getCurrentUser().getUser().getId()) {
+            throw new EntityNotFoundException(DriverAvailability.class, id);
+        }
+
         availability.setDay(incoming.getDay());
         availability.setStartTime(incoming.getStartTime());
         availability.setEndTime(incoming.getEndTime());
@@ -119,7 +127,11 @@ public class DriverAvailabilityController extends ApiController{
             @Parameter(name="id") @RequestParam Long id) {
         DriverAvailability availability = driverAvailabilityRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(DriverAvailability.class, id));
-
+        
+        if (availability.getDriverId() != getCurrentUser().getUser().getId()) {
+            throw new EntityNotFoundException(DriverAvailability.class, id);
+        }
+        
         driverAvailabilityRepository.delete(availability);
         return genericMessage("DriverAvailability with id %s deleted".formatted(id));
     }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -268,7 +268,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
                         .build();
 
         DriverAvailability availability_edited = DriverAvailability.builder()
-                        .driverId(DriverId) // User should not be able to change this
+                        .driverId(7)
                         .day("Tuesday")
                         .startTime("5:00 AM")
                         .endTime("12:00 PM")

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -269,9 +269,9 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
         DriverAvailability availability_edited = DriverAvailability.builder()
                         .driverId(DriverId)
-                        .day("12/24/2024")
-                        .startTime("5:00AM")
-                        .endTime("12:00PM")
+                        .day("Tuesday")
+                        .startTime("5:00 AM")
+                        .endTime("12:00 PM")
                         .notes("Early Shift")
                         .build();
 

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -67,13 +67,14 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     @WithMockUser(roles = { "DRIVER" })
     @Test
     public void a_driver_can_post_a_new_driverAvailability() throws Exception {
-        Long UserId = currentUserService.getCurrentUser().getUser().getId();
+
+        // Long UserId = currentUserService.getCurrentUser().getUser().getId();
 
         DriverAvailability availability1 = DriverAvailability.builder()
                         .driverId(1)
-                        .day("03/05/2024")
-                        .startTime("10:30AM")
-                        .endTime("2:30PM")
+                        .day("Monday")
+                        .startTime("10:30 AM")
+                        .endTime("2:30 PM")
                         .notes("End for late lunch")
                         .build();
 
@@ -81,7 +82,7 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                        post("/api/driverAvailability/new?driverId=1&day=03/05/2024&startTime=10:30AM&endTime=2:30PM&notes=End for late lunch")
+                        post("/api/driverAvailability/new?driverId=1&day=Monday&startTime=10:30 AM&endTime=2:30 PM&notes=End for late lunch")
                                         .with(csrf()))
                         .andExpect(status().isOk()).andReturn();
 
@@ -124,17 +125,17 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
         DriverAvailability availability1 = DriverAvailability.builder()
                         .driverId(1)
-                        .day("03/05/2024")
-                        .startTime("10:30AM")
-                        .endTime("2:30PM")
+                        .day("Monday")
+                        .startTime("10:30 AM")
+                        .endTime("2:30 PM")
                         .notes("End for late lunch")
                         .build();
 
         DriverAvailability availability2 = DriverAvailability.builder()
                         .driverId(2)
-                        .day("12/24/2024")
-                        .startTime("5:00AM")
-                        .endTime("12:00PM")
+                        .day("Tuesday")
+                        .startTime("5:00 AM")
+                        .endTime("12:00 PM")
                         .notes("Early Shift")
                         .build();
 
@@ -183,13 +184,13 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     @Test
     public void test_that_logged_in_driver_can_get_by_id_when_the_id_exists_and_user_id_matches() throws Exception {
         
-        Long UserId = currentUserService.getCurrentUser().getUser().getId();
+        // Long UserId = currentUserService.getCurrentUser().getUser().getId();
 
         DriverAvailability availability = DriverAvailability.builder()
                         .driverId(1)
-                        .day("03/05/2024")
-                        .startTime("10:30AM")
-                        .endTime("2:30PM")
+                        .day("Monday")
+                        .startTime("10:30 AM")
+                        .endTime("2:30 PM")
                         .notes("End for late lunch")
                         .build();
 
@@ -260,17 +261,17 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
         DriverAvailability availability_original = DriverAvailability.builder()
                         .driverId(DriverId)
-                        .day("03/05/2024")
-                        .startTime("10:30AM")
-                        .endTime("2:30PM")
+                        .day("Monday")
+                        .startTime("10:30 AM")
+                        .endTime("2:30 PM")
                         .notes("End for late lunch")
                         .build();
 
         DriverAvailability availability_edited = DriverAvailability.builder()
-                        .driverId(7)
-                        .day("12/24/2024")
-                        .startTime("5:00AM")
-                        .endTime("12:00PM")
+                        .driverId(DriverId) // User should not be able to change this
+                        .day("Tuesday")
+                        .startTime("5:00 AM")
+                        .endTime("12:00 PM")
                         .notes("Early Shift")
                         .build();
 
@@ -302,9 +303,9 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
             DriverAvailability availability_edited = DriverAvailability.builder()
                         .driverId(DriverId)
-                        .day("12/24/2024")
-                        .startTime("5:00AM")
-                        .endTime("12:00PM")
+                        .day("Monday")
+                        .startTime("5:00 AM")
+                        .endTime("12:00 PM")
                         .notes("Early Shift")
                         .build();
                         
@@ -358,9 +359,9 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
 
         DriverAvailability availability = DriverAvailability.builder()
                 .driverId(1)
-                .day("12/24/2024")
-                .startTime("5:00AM")
-                .endTime("12:00PM")
+                .day("Tuesday")
+                .startTime("5:00 AM")
+                .endTime("12:00 PM")
                 .notes("Early Shift")
                 .build();
 
@@ -427,13 +428,13 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
     @Test
     public void test_that_logged_in_admin_can_get_by_id_when_the_id_exists_and_user_id_matches() throws Exception {
         
-        Long UserId = currentUserService.getCurrentUser().getUser().getId();
+        // Long UserId = currentUserService.getCurrentUser().getUser().getId();
 
         DriverAvailability availability = DriverAvailability.builder()
                         .driverId(1)
-                        .day("03/05/2024")
-                        .startTime("10:30AM")
-                        .endTime("2:30PM")
+                        .day("Monday")
+                        .startTime("10:30 AM")
+                        .endTime("2:30 PM")
                         .notes("End for late lunch")
                         .build();
 
@@ -510,18 +511,18 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
         Long otherUserId = UserId + 1;
 
         DriverAvailability availability1 = DriverAvailability.builder()
-                        .driverId(1)
-                        .day("02/29/2024")
-                        .startTime("10:30AM")
-                        .endTime("2:30PM")
+                        .driverId(UserId)
+                        .day("Monday")
+                        .startTime("10:30 AM")
+                        .endTime("2:30 PM")
                         .notes("End for late lunch")
                         .build();
 
         DriverAvailability availability2 = DriverAvailability.builder()
-                        .driverId(1)
-                        .day("03/05/2024")
-                        .startTime("12:30PM")
-                        .endTime("5:30PM")
+                        .driverId(otherUserId)
+                        .day("Tuesday")
+                        .startTime("12:30 PM")
+                        .endTime("5:30 PM")
                         .notes("Last shift of the day")
                         .build();
         

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverAvailabilityControllerTests.java
@@ -268,10 +268,10 @@ public class DriverAvailabilityControllerTests extends ControllerTestCase {
                         .build();
 
         DriverAvailability availability_edited = DriverAvailability.builder()
-                        .driverId(7)
-                        .day("Tuesday")
-                        .startTime("5:00 AM")
-                        .endTime("12:00 PM")
+                        .driverId(DriverId)
+                        .day("12/24/2024")
+                        .startTime("5:00AM")
+                        .endTime("12:00PM")
                         .notes("Early Shift")
                         .build();
 


### PR DESCRIPTION
## Dokku: https://gauchoride-qa.dokku-16.cs.ucsb.edu

(Deployed on gauchoride-qa as gauchoride-xinyao-dev is taken for PR #23 concurrently)

The PR modifies the `DriverAvailabilitiesForm` page so a driver can understand what each field in the `Create Availability Form` means and submit a correct availability without running into issues. Furthermore, the PR removed the necessity for drivers to input their `driver ID` each time they submit an availability form where the `driver ID` is automatically recorded. In this case, most number of changed lines is due to a combination of having to touch related documentation to the `driverId` field and adding new tests. 

### Testing Instructions:
1. Click `Admin` in the nav bar and go the `Users` page to toggle `Driver` under your name. 
2. Once `Driver` is being toggled, click `Shifts` in the nav bar and go to the `Availability` page. 
3. From there you can see a button called `Create Driver Availability` and that is where you can fill out a driver availability form and test out the functionality of this PR. 

### Acceptance Criteria:

- [ ] The form labels are improved so that each word are spaced out and is easily readable to the user. 
- [ ] The bad input and missing input error messages are added for `Start Time`, `End Time`, and `Day of the Week`. 
- [ ] There are example inputs on each form field which helps the user to know what to put there. 
- [ ] `DriverId` is removed from all aspects of DriverAvailability, including `DriverAvailabilityController.java`, `DriverAvailabilityForm.js`, `DriverAvailabilityEditPage.js`, and `DriverAvailabilityCreatePage.js`. 
- [ ] User is able to input additional notes in the `notes` field if there are anything additional to say. 

### Frontend Preview:
#### Before:
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/448b6577-033f-4a07-a03d-13bd7d9b69d6)
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/dbeed783-7f61-4175-83b0-cb5412dd81f8)
![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/3cea36aa-052a-4ca1-a75c-642a2a871ceb)

#### After: 
<img width="1439" alt="Screenshot 2024-05-25 at 8 36 45 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/198f261f-fb88-41bd-92aa-b530932cfb53">
<img width="1440" alt="Screenshot 2024-05-25 at 8 36 52 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/07a6a344-e4d9-44d6-8a49-f312a1dc4a61">
 
**Example of driver's availability created without additional notes (id:8):** 
<img width="1440" alt="Screenshot 2024-05-25 at 8 37 08 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/d3cda159-7bce-4e8f-928a-725381c1d64c">

**Example of driver's availability created with additional notes (id:9):** 
<img width="1440" alt="Screenshot 2024-05-25 at 8 37 39 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/42160992/1f42e3d1-502b-4bf9-aad6-fc8dd1942e8e">
Closes #11 