### PR TITLE
KL - FEATURE: Admin should be able to select driver from dropdown for assigning ride request

### DIFF
--- a/frontend/src/main/components/Ride/RideAssignDriverForm.js
+++ b/frontend/src/main/components/Ride/RideAssignDriverForm.js
@@ -2,12 +2,59 @@ import React, { useEffect, useState } from 'react'
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom';
-
+import { useBackend } from 'main/utils/useBackend';
 
 
 function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "Assign Driver" }) {
     const navigate = useNavigate();
-    
+
+    // Stryker disable all  
+    const { data: drivers } =
+        useBackend(
+            [`/api/drivers/all`],
+            {  
+                method: "GET",
+                url: `/api/drivers/all`
+                
+            },
+        );
+    // Stryker restore all
+
+    // Stryker disable all
+    const { data: shifts } =
+        useBackend(
+            
+            [`/api/shift/all`],
+            {  
+                method: "GET",
+                url: `/api/shift/all`
+                
+            },
+        );
+    // Stryker restore all
+
+    // Stryker disable all
+    const [Shifts, setShift] = useState([]);
+    useEffect(() => {
+        if (drivers && shifts) {
+            var driverMap = new Map();
+            
+            drivers.forEach(driver => {
+                driverMap.set(driver.id, driver.fullName);
+            });
+
+            shifts.forEach(shift => {
+                setShift(prevShifts => [...prevShifts, {
+                    id: shift.id,
+                    driver: driverMap.get(shift.driverID),
+                    day: shift.day,
+                    shiftStart: shift.shiftStart,
+                    shiftEnd: shift.shiftEnd,
+                }]);
+            });
+        }
+    }, [drivers, shifts]);
+    // Stryker restore all
 
     // Stryker disable all
     const {
@@ -17,46 +64,7 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
     } = useForm(
         { defaultValues: initialContents }
     );
-
-
-    const [shifts, setShifts] = useState([]);
-    useEffect(() => {
-        // Fetch the shifts from the backend
-        const fetchShifts = async () => {
-            try {
-                const response = await fetch('/api/shift/all');
-                const data = await response.json();
-                setShifts(data);
-            } catch (error) {
-                console.error('Error fetching shifts:', error);
-            }
-        };
-        fetchShifts();
-    }, []);
-
-    const [driver, setDriver] = useState([]);
-    useEffect(() => {
-        // Fetch the shifts from the backend
-        const fetchShifts = async () => {
-            try {
-                const response = await fetch('/api/drivers/all');
-                const data = await response.json();
-                setDriver(data);
-            } catch (error) {
-                console.error('Error fetching shifts:', error);
-            }
-        };
-        fetchShifts();
-    }, []);
-
-    shifts.forEach(shifts => {   // link the driver to the shift
-        driver.forEach(driver => {
-            if (shifts.driverID === driver.id) {
-                shifts.driver = driver.fullName;
-            }
-        });
-    });
-
+    // Stryker restore all
 
     const testIdPrefix = "RideAssignDriverForm";
 
@@ -79,29 +87,20 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
                 </Form.Group>
             )}
 
-            
-
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="shiftId">Shift Id</Form.Label>
                 <Form.Select
                     data-testid={testIdPrefix + "-shiftId"}
                     id="shiftId"
+                    {...register("shiftId")}
                     defaultValue={initialContents?.shiftId}
-                    isInvalid={Boolean(errors.shiftId)}
-
-                    {...register("shiftId", {
-                        required: "Shift Id is required."
-                    })}
                 >
-                    {shifts.map(shifts=> (
-                        <option key={shifts.id} value={shifts.id}>
-                            {shifts.id} - {shifts.driver} - {shifts.day} {shifts.shiftStart}-{shifts.shiftEnd}
+                    {Shifts.map((shift) => (
+                        <option key={shift.id} data-testid={testIdPrefix + "-shiftId-" + shift.id} value={shift.id}>
+                           {shift.id} - {shift.driver} - {shift.day} {shift.shiftStart}-{shift.shiftEnd}
                         </option>
                     ))}
                 </Form.Select>
-                <Form.Control.Feedback type="invalid">
-                    {errors.shiftId?.message}
-                </Form.Control.Feedback>
             </Form.Group>
 
             <Form.Group className="mb-3" >
@@ -136,10 +135,10 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
                     type="text"
                     {...register("end")}
                     disabled
-                    defaultValue={initialContents?.endTime}     
+                    defaultValue={initialContents?.endTime}
                 />
             </Form.Group>
-            
+
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="pickupBuilding">Pick Up Building</Form.Label>
                 <Form.Control
@@ -149,7 +148,7 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
                     isInvalid={Boolean(errors.pickupBuilding)}
                     {...register("pickupBuilding")}
                     disabled
-                    defaultValue={initialContents?.pickupBuilding} 
+                    defaultValue={initialContents?.pickupBuilding}
                 />
             </Form.Group>
 
@@ -162,7 +161,7 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
                     isInvalid={Boolean(errors.pickupRoom)}
                     {...register("pickupRoom")}
                     disabled
-                    defaultValue={initialContents?.pickupRoom} 
+                    defaultValue={initialContents?.pickupRoom}
                 />
             </Form.Group>
 
@@ -188,7 +187,7 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
                     isInvalid={Boolean(errors.dropoffRoom)}
                     {...register("dropoffRoom")}
                     disabled
-                    defaultValue={initialContents?.dropoffRoom} 
+                    defaultValue={initialContents?.dropoffRoom}
                 />
             </Form.Group>
 
@@ -201,7 +200,7 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
                     isInvalid={Boolean(errors.course)}
                     {...register("course")}
                     disabled
-                    defaultValue={initialContents?.course} 
+                    defaultValue={initialContents?.course}
                 />
             </Form.Group>
 
@@ -214,7 +213,7 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
                     isInvalid={Boolean(errors.notes)}
                     {...register("notes")}
                     disabled
-                    defaultValue={initialContents?.notes} 
+                    defaultValue={initialContents?.notes}
                 />
             </Form.Group>
 

--- a/frontend/src/main/components/Ride/RideAssignDriverForm.js
+++ b/frontend/src/main/components/Ride/RideAssignDriverForm.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom';
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "Assign Driver" }) {
     const navigate = useNavigate();
     
+
     // Stryker disable all
     const {
         register,
@@ -16,8 +17,47 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
     } = useForm(
         { defaultValues: initialContents }
     );
-    // Stryker enable all
-   
+
+
+    const [shifts, setShifts] = useState([]);
+    useEffect(() => {
+        // Fetch the shifts from the backend
+        const fetchShifts = async () => {
+            try {
+                const response = await fetch('/api/shift/all');
+                const data = await response.json();
+                setShifts(data);
+            } catch (error) {
+                console.error('Error fetching shifts:', error);
+            }
+        };
+        fetchShifts();
+    }, []);
+
+    const [driver, setDriver] = useState([]);
+    useEffect(() => {
+        // Fetch the shifts from the backend
+        const fetchShifts = async () => {
+            try {
+                const response = await fetch('/api/drivers/all');
+                const data = await response.json();
+                setDriver(data);
+            } catch (error) {
+                console.error('Error fetching shifts:', error);
+            }
+        };
+        fetchShifts();
+    }, []);
+
+    shifts.forEach(shifts => {   // link the driver to the shift
+        driver.forEach(driver => {
+            if (shifts.driverID === driver.id) {
+                shifts.driver = driver.fullName;
+            }
+        });
+    });
+
+
     const testIdPrefix = "RideAssignDriverForm";
 
 
@@ -43,18 +83,24 @@ function RideAssignDriverForm({ initialContents, submitAction, buttonLabel = "As
 
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="shiftId">Shift Id</Form.Label>
-                <Form.Control
+                <Form.Select
                     data-testid={testIdPrefix + "-shiftId"}
                     id="shiftId"
-                    type="text"
-                    isInvalid={Boolean(errors.pickupBuilding)}
+                    defaultValue={initialContents?.shiftId}
+                    isInvalid={Boolean(errors.shiftId)}
+
                     {...register("shiftId", {
-                        required: "Shift Id Up Building is required."
+                        required: "Shift Id is required."
                     })}
-                    defaultValue={initialContents?.pickupBuilding} 
-                />
+                >
+                    {shifts.map(shifts=> (
+                        <option key={shifts.id} value={shifts.id}>
+                            {shifts.id} - {shifts.driver} - {shifts.day} {shifts.shiftStart}-{shifts.shiftEnd}
+                        </option>
+                    ))}
+                </Form.Select>
                 <Form.Control.Feedback type="invalid">
-                    {errors.pickupBuilding?.message}
+                    {errors.shiftId?.message}
                 </Form.Control.Feedback>
             </Form.Group>
 

--- a/frontend/src/tests/components/Ride/RideAssignDriverForm.test.js
+++ b/frontend/src/tests/components/Ride/RideAssignDriverForm.test.js
@@ -6,6 +6,12 @@ import { rideFixtures } from "fixtures/rideFixtures";
 
 import { QueryClient, QueryClientProvider } from "react-query";
 
+import driverFixtures from "fixtures/driverFixtures";
+import shiftFixtures from "fixtures/shiftFixtures";
+import axios from "axios";
+import axiosMockAdapter from "axios-mock-adapter";
+
+
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
@@ -18,6 +24,16 @@ describe("RideAssignDriverForm tests", () => {
 
     const expectedHeaders = ["Shift Id", "Day of Week", "Start Time", "End Time", "Pick Up Building", "Drop Off Building", "Room Number for Dropoff", "Course Number"];
     const testId = "RideAssignDriverForm";
+
+    const axiosMock = new axiosMockAdapter(axios);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/drivers").reply(200, driverFixtures.threeDrivers);
+        axiosMock.onGet("/api/shifts").reply(200, shiftFixtures.threeShifts);
+    });
 
     test("renders correctly with no initialContents", async () => {
         render(

--- a/frontend/src/tests/pages/Ride/RideRequestAssignPage.test.js
+++ b/frontend/src/tests/pages/Ride/RideRequestAssignPage.test.js
@@ -9,6 +9,8 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import mockConsole from "jest-mock-console";
+import drivershiftsFixtures from "fixtures/drivershiftsFixtures";
+import driverFixtures from "fixtures/driverFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -44,6 +46,8 @@ describe("RideRequestAssignPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/shift/all").reply(200, drivershiftsFixtures.threeShifts);
+            axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
             axiosMock.onGet("/api/ride_request", { params: { id: 17 } }).timeout();
         });
 
@@ -52,7 +56,7 @@ describe("RideRequestAssignPage tests", () => {
 
             const restoreConsole = mockConsole();
 
-            const {queryByTestId, findByText} = render(
+            const { queryByTestId, findByText } = render(
                 <QueryClientProvider client={queryClient}>
                     <MemoryRouter>
                         <RideRequestAssignPage />
@@ -74,12 +78,14 @@ describe("RideRequestAssignPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/shift/all").reply(200, drivershiftsFixtures.threeShifts);
+            axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
             axiosMock.onGet("/api/ride_request", { params: { id: 17 } }).reply(200, {
                 id: 17,
                 shiftId: 1,
                 day: "Tuesday",
                 startTime: "5:00PM",
-                endTime: "7:30PM", 
+                endTime: "7:30PM",
                 pickupBuilding: "HSSB",
                 dropoffBuilding: "SRB",
                 dropoffRoom: "125",
@@ -92,7 +98,7 @@ describe("RideRequestAssignPage tests", () => {
                 shiftId: 3,
                 day: "Monday",
                 startTime: "3:30PM",
-                endTime: "4:30PM", 
+                endTime: "4:30PM",
                 pickupBuilding: "Phelps",
                 dropoffBuilding: "HSSB",
                 dropoffRoom: "1215",
@@ -124,8 +130,8 @@ describe("RideRequestAssignPage tests", () => {
             );
 
             await findByTestId("RideAssignDriverForm-day");
-            
-            const shiftIdField = getByTestId("RideAssignDriverForm-shiftId")
+
+            const shiftIdField = await waitFor(() => getByTestId("RideAssignDriverForm-shiftId"))
             const dayField = getByTestId("RideAssignDriverForm-day");
             const startTimeField = getByTestId("RideAssignDriverForm-start");
             const endTimeField = getByTestId("RideAssignDriverForm-end");
@@ -135,7 +141,7 @@ describe("RideRequestAssignPage tests", () => {
             const pickupRoomField = getByTestId("RideAssignDriverForm-pickupRoom");
             const courseField = getByTestId("RideAssignDriverForm-course");
             const notesField = getByTestId("RideAssignDriverForm-notes");
-            
+
             expect(shiftIdField).toHaveValue("1");
             expect(dayField).toHaveValue("Tuesday");
             expect(startTimeField).toHaveValue("5:00PM");
@@ -146,12 +152,12 @@ describe("RideRequestAssignPage tests", () => {
             expect(pickupRoomField).toHaveValue("1111");
             expect(courseField).toHaveValue("CMPSC 156");
             expect(notesField).toHaveValue("note1");
-            
+
         });
 
         test("Changes when you click Update", async () => {
 
-                
+
 
             const { getByTestId, findByTestId } = render(
                 <QueryClientProvider client={queryClient}>
@@ -163,7 +169,7 @@ describe("RideRequestAssignPage tests", () => {
 
             await findByTestId("RideAssignDriverForm-day");
 
-            const shiftIdField = getByTestId("RideAssignDriverForm-shiftId")
+            const shiftIdField = await waitFor(() => getByTestId("RideAssignDriverForm-shiftId"))
             const dayField = getByTestId("RideAssignDriverForm-day");
             const startTimeField = getByTestId("RideAssignDriverForm-start");
             const endTimeField = getByTestId("RideAssignDriverForm-end");
@@ -188,7 +194,7 @@ describe("RideRequestAssignPage tests", () => {
 
 
             expect(submitButton).toBeInTheDocument();
-            
+
             fireEvent.change(shiftIdField, { target: { value: '3' } })
             fireEvent.change(dayField, { target: { value: 'Monday' } })
             fireEvent.change(startTimeField, { target: { value: '3:30PM' } })
@@ -201,7 +207,7 @@ describe("RideRequestAssignPage tests", () => {
 
             fireEvent.click(submitButton);
 
-    
+
             await waitFor(() => expect(mockToast).toHaveBeenCalled());
             expect(mockToast).toBeCalledWith("Driver Assigned - id: 17");
             expect(mockNavigate).toBeCalledWith({ "to": "/ride/" });
@@ -214,6 +220,6 @@ describe("RideRequestAssignPage tests", () => {
 
         });
 
-       
+
     });
 });

--- a/frontend/src/tests/pages/Ride/RideRequestAssignPage.test.js
+++ b/frontend/src/tests/pages/Ride/RideRequestAssignPage.test.js
@@ -132,6 +132,7 @@ describe("RideRequestAssignPage tests", () => {
             await findByTestId("RideAssignDriverForm-day");
 
             const shiftIdField = await waitFor(() => getByTestId("RideAssignDriverForm-shiftId"))
+            const shiftIdFieldId = await waitFor(() => getByTestId("RideAssignDriverForm-shiftId-1"))
             const dayField = getByTestId("RideAssignDriverForm-day");
             const startTimeField = getByTestId("RideAssignDriverForm-start");
             const endTimeField = getByTestId("RideAssignDriverForm-end");
@@ -141,7 +142,9 @@ describe("RideRequestAssignPage tests", () => {
             const pickupRoomField = getByTestId("RideAssignDriverForm-pickupRoom");
             const courseField = getByTestId("RideAssignDriverForm-course");
             const notesField = getByTestId("RideAssignDriverForm-notes");
+            
 
+            expect(shiftIdFieldId).toBeInTheDocument();
             expect(shiftIdField).toHaveValue("1");
             expect(dayField).toHaveValue("Tuesday");
             expect(startTimeField).toHaveValue("5:00PM");


### PR DESCRIPTION
I added a dropdown list to assign a driver with a shift to a ride in the Admin view of the assigning ride request menu. 
I had to fetch the shift and driver information from the backend, matched them together and mapped them to the dropdown list. 

Acceptance criteria: 
 When assigning a driver/shift to a ride request, an admin can select from a list of shifts in a dropdown menu as opposed to a text field. 

Dokku deployed link: https://gauchoride-karstenlansing-dev.dokku-16.cs.ucsb.edu

Preview 

<img width="1374" alt="Screenshot 2024-05-21 at 12 57 53" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/43016839/51822ddb-664f-4cbb-8527-16f7568b1baf">

<img width="1374" alt="Screenshot 2024-05-21 at 12 58 06" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/43016839/166e0c3f-7e90-47e5-9385-3c8c604a5406">

Closes #14 