### PR TITLE
AV-Created ToggleRider Feature for Rider Applications

### DIFF
--- a/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
+++ b/frontend/src/main/components/RiderApplication/RiderApplicationEditForm.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom';
+import { useBackendMutation } from 'main/utils/useBackend';
 
 function RiderApplicationEditForm({ initialContents, submitAction, email}) {
     const navigate = useNavigate();
@@ -23,9 +24,30 @@ function RiderApplicationEditForm({ initialContents, submitAction, email}) {
         submitAction(data);
     };
     
-    const handleApprove = () => {
+    function cellToAxiosParamsToggleRider(id) {
+        return {
+            url: "/api/admin/users/toggleRider",
+            method: "POST",
+            params: {
+                id: id
+            }
+        }
+    }
+    // Stryker disable all : hard to test for query caching
+    const toggleRiderMutation = useBackendMutation(
+        cellToAxiosParamsToggleRider,
+        {},
+        ["/api/admin/users"]
+    );
+    // Stryker enable all 
+
+    const toggleRiderCallback = async (id) => { toggleRiderMutation.mutate(id); }
+
+    const handleApprove = async () => {
         const updatedData = { ...initialContents, status: 'accepted' , notes: getValues("notes") };
-        handleAction(updatedData, -1);
+        submitAction(updatedData);
+        await toggleRiderCallback(initialContents.userId);
+        navigate(-1);
     };
 
     const handleDeny = () => {

--- a/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
+++ b/frontend/src/tests/components/RiderApplication/RiderApplicationEditForm.test.js
@@ -19,10 +19,20 @@ describe("RiderApplicationEditForm tests", () => {
     const expectedHeaders = ["Email", "Description"];
     const testId = "RiderApplicationEditForm";
 
+    const renderWithProviders = (ui) => {
+        return render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    {ui}
+                </Router>
+            </QueryClientProvider>
+        );
+    };
+
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        render(
+        renderWithProviders(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -54,7 +64,7 @@ describe("RiderApplicationEditForm tests", () => {
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        render(
+        renderWithProviders(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -86,7 +96,7 @@ describe("RiderApplicationEditForm tests", () => {
     test('handleAction submits data and navigates', async () => {
         const mockSubmitAction = jest.fn();
     
-        render(
+        renderWithProviders(
             <RiderApplicationEditForm
                 initialContents={{ id: 1,
                     userId: 'user123',
@@ -116,12 +126,8 @@ describe("RiderApplicationEditForm tests", () => {
     });
 
     test("renders correctly with no initialContents", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm />
-                </Router>
-            </QueryClientProvider>
+        renderWithProviders(
+            <RiderApplicationEditForm />
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -134,12 +140,8 @@ describe("RiderApplicationEditForm tests", () => {
     });
 
     test("renders correctly when passing in initialContents", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm initialContents={riderApplicationFixtures.oneRiderApplication} />
-                </Router>
-            </QueryClientProvider>
+        renderWithProviders(
+            <RiderApplicationEditForm initialContents={riderApplicationFixtures.oneRiderApplication} />
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -151,10 +153,8 @@ describe("RiderApplicationEditForm tests", () => {
     });
 
     test("renders correctly when passing in initialContents with status declined", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm initialContents={{ id: 1,
+        renderWithProviders(
+            <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
                     status: 'declined',
                     email: 'test@example.com',
@@ -164,8 +164,6 @@ describe("RiderApplicationEditForm tests", () => {
                     notes: 'This is a note.',
                     perm_number: '1234567',
                     description: 'This is a test description.', }} />
-                </Router>
-            </QueryClientProvider>
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -177,10 +175,8 @@ describe("RiderApplicationEditForm tests", () => {
     });
 
     test("renders correctly when passing in initialContents with status cancelled", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm initialContents={{ id: 1,
+        renderWithProviders(
+            <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
                     status: 'cancelled',
                     email: 'test@example.com',
@@ -190,8 +186,6 @@ describe("RiderApplicationEditForm tests", () => {
                     notes: 'This is a note.',
                     perm_number: '1234567',
                     description: 'This is a test description.', }} />
-                </Router>
-            </QueryClientProvider>
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -203,10 +197,8 @@ describe("RiderApplicationEditForm tests", () => {
     });
 
     test("renders correctly when passing in initialContents with status expired", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm initialContents={{ id: 1,
+        renderWithProviders(
+            <RiderApplicationEditForm initialContents={{ id: 1,
                     userId: 'user123',
                     status: 'expired',
                     email: 'test@example.com',
@@ -216,8 +208,6 @@ describe("RiderApplicationEditForm tests", () => {
                     notes: 'This is a note.',
                     perm_number: '1234567',
                     description: 'This is a test description.', }} />
-                </Router>
-            </QueryClientProvider>
         );
 
         expect(await screen.findByText(/Return/)).toBeInTheDocument();
@@ -230,12 +220,8 @@ describe("RiderApplicationEditForm tests", () => {
 
 
     test("that navigate(-1) is called when Cancel is clicked", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <Router>
-                    <RiderApplicationEditForm />
-                </Router>
-            </QueryClientProvider>
+        renderWithProviders(
+            <RiderApplicationEditForm />
         );
         expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
         const cancelButton = screen.getByTestId(`${testId}-cancel`);


### PR DESCRIPTION
As an admin, I can accept rider applications that will automatically assign the user to be a rider so that I don't have to manually change their roles in the user table.

Discussion
Right now, when a ride application is accepted, only the status of the ride application is changed. So the admin has to go to the table of users and find the user who submitted the application and manually toggle their role.

What is better is, if the application is accepted, then the user who submitted the application gains the role automatically.

Acceptance Criteria
When an admin accepts a rider application through the review form, the user gains the Rider role.

In RiderApplicationEditForm.js modify the handleApprove method to include toggling of the applicant's role. You can look at UsersTable.js to see how it is done there and adapt appropriately.

Updated Behavior:
![ToggleRide](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/124840028/c9182a42-865a-464a-8d89-31c9caf7e75f)
As seen from the clip above, once a rider application is approved by an admin, it toggles Rider to True for that user.

Closes #9 