### PR TITLE
Kl - FEATURE: Change Driver Id text fields to dropdown

### DIFF
--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -137,7 +137,7 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     {...register("driverBackupID")}
                 >
                 {drivers && drivers.map((driver) => (
-                    <option key={driver.id} data-testid={testIdPrefix + "-driverId-" + driver.id}  value={driver.id.toString()}>{driver.id} - {driver.fullName}</option>
+                    <option key={driver.id} data-testid={testIdPrefix + "-driverBackupId-" + driver.id}  value={driver.id.toString()}>{driver.id} - {driver.fullName}</option>
                 ))}
                 </Form.Select>
             </Form.Group>

--- a/frontend/src/main/components/Shift/ShiftForm.js
+++ b/frontend/src/main/components/Shift/ShiftForm.js
@@ -1,6 +1,8 @@
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
+import { useBackend } from 'main/utils/useBackend';
+import React from 'react'
 
 function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
     // Stryker disable all
@@ -9,7 +11,17 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
         formState: { errors },
         handleSubmit,
     } = useForm({ defaultValues: initialContents || {} });
+
+    const { data: drivers, _error, _status } =
+        useBackend(
+            [`/api/drivers/all`],
+            {
+                method: "GET",
+                url: `/api/drivers/all`
+            },
+        );
     // Stryker restore all
+
     const navigate = useNavigate();
     const testIdPrefix = "ShiftForm";
 
@@ -103,36 +115,31 @@ function ShiftForm({ initialContents, submitAction, buttonLabel = "Create" }) {
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="driverID">Driver ID</Form.Label>
-                <Form.Control
+                <Form.Select
                     data-testid={testIdPrefix + "-driverID"}
                     id="driverID"
                     name="driverID"
-                    type="number"
-                    isInvalid={Boolean(errors.driverID)}
-                    {...register("driverID", {
-                        required: "Driver ID is required."
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.driverID?.message}
-                </Form.Control.Feedback>
+                    {...register("driverID")}
+                >
+                {drivers && drivers.map((driver) => (
+                    <option key={driver.id} data-testid={testIdPrefix + "-driverId-" + driver.id} value={driver.id.toString()}>{driver.id} - {driver.fullName}</option>
+                ))
+                }
+                </Form.Select>
             </Form.Group>
 
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="driverBackupID">Driver Backup ID</Form.Label>
-                <Form.Control
+                <Form.Select
                     data-testid={testIdPrefix + "-driverBackupID"}
                     id="driverBackupID"
                     name="driverBackupID"
-                    type="number"
-                    isInvalid={Boolean(errors.driverBackupID)}
-                    {...register("driverBackupID", {
-                        required: "Driver Backup ID is required."
-                    })}
-                />
-                <Form.Control.Feedback type="invalid">
-                    {errors.driverBackupID?.message}
-                </Form.Control.Feedback>
+                    {...register("driverBackupID")}
+                >
+                {drivers && drivers.map((driver) => (
+                    <option key={driver.id} data-testid={testIdPrefix + "-driverId-" + driver.id}  value={driver.id.toString()}>{driver.id} - {driver.fullName}</option>
+                ))}
+                </Form.Select>
             </Form.Group>
 
             <Button

--- a/frontend/src/tests/components/Shift/ShiftForm.test.js
+++ b/frontend/src/tests/components/Shift/ShiftForm.test.js
@@ -67,6 +67,9 @@ describe("ShiftForm tests", () => {
 
         expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
         expect(screen.getByText(`Id`)).toBeInTheDocument();
+
+        expect(screen.getByTestId("ShiftForm-driverId-1")).toBeInTheDocument();
+        expect(screen.getByTestId("ShiftForm-driverBackupId-1")).toBeInTheDocument();
     });
 
 
@@ -366,5 +369,5 @@ describe("ShiftForm tests", () => {
     
         // Resetting input
         fireEvent.change(shiftEndInput, { target: { value: "" } });
-    }); 
+    });
 });

--- a/frontend/src/tests/components/Shift/ShiftForm.test.js
+++ b/frontend/src/tests/components/Shift/ShiftForm.test.js
@@ -2,9 +2,13 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import ShiftForm from "main/components/Shift/ShiftForm";
-import { shiftFixtures } from "fixtures/shiftFixtures";
 
 import { QueryClient, QueryClientProvider } from "react-query";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import driverFixtures from "fixtures/driverFixtures";
+import shiftFixtures from "fixtures/shiftFixtures";
 
 const mockedNavigate = jest.fn();
 
@@ -18,6 +22,15 @@ describe("ShiftForm tests", () => {
 
     const expectedHeaders = ["Day of the Week", "Shift Start","Shift End","Driver ID","Driver Backup ID"];
     const testId = "ShiftForm";
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
+    });
+
 
     test("renders correctly with no initialContents", async () => {
         render(
@@ -34,7 +47,6 @@ describe("ShiftForm tests", () => {
             const header = screen.getByText(headerText);
             expect(header).toBeInTheDocument();
         });
-
     });
 
     test("renders correctly when passing in initialContents", async () => {
@@ -90,8 +102,6 @@ describe("ShiftForm tests", () => {
         await screen.findByText(/Day is required/);
         expect(screen.getByText(/Shift start time is required/)).toBeInTheDocument();
         expect(screen.getByText(/Shift end time is required/)).toBeInTheDocument();
-        expect(screen.getByText(/Driver ID is required/)).toBeInTheDocument();
-        expect(screen.getByText(/Driver Backup ID is required/)).toBeInTheDocument();
 
 
     });
@@ -157,8 +167,6 @@ describe("ShiftForm tests", () => {
         //expect(screen.getByText("Day is required.")).toBeInTheDocument();
         expect(screen.getByText("Shift start time is required.")).toBeInTheDocument();
         expect(screen.getByText("Shift end time is required.")).toBeInTheDocument();
-        expect(screen.getByText("Driver ID is required.")).toBeInTheDocument();
-        expect(screen.getByText("Driver Backup ID is required.")).toBeInTheDocument();
     });
 
     test("validates specific time format anomalies", async () => {
@@ -358,9 +366,5 @@ describe("ShiftForm tests", () => {
     
         // Resetting input
         fireEvent.change(shiftEndInput, { target: { value: "" } });
-    });
-    
-    
-    
-    
+    }); 
 });

--- a/frontend/src/tests/pages/Shift/ShiftCreatePage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftCreatePage.test.js
@@ -5,6 +5,8 @@ import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import driverFixtures from "fixtures/driverFixtures";
+
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
@@ -37,6 +39,7 @@ describe("ShiftCreatePage tests", () => {
         jest.clearAllMocks();
         axiosMock.reset();
         axiosMock.resetHistory();
+        axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     });
@@ -82,7 +85,8 @@ describe("ShiftCreatePage tests", () => {
         )
 
         await waitFor(() => {
-            expect(screen.getByLabelText("Day of the Week")).toBeInTheDocument();
+            expect(screen.getByLabelText("Driver ID")).toBeInTheDocument();
+            expect(screen.getByLabelText("Driver Backup ID")).toBeInTheDocument();
         });
 
         // Test for Day input

--- a/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
+++ b/frontend/src/tests/pages/Shift/ShiftEditPage.test.js
@@ -9,6 +9,7 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import mockConsole from "jest-mock-console";
+import driverFixtures from "fixtures/driverFixtures";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {
@@ -45,6 +46,7 @@ describe("ShiftEditPage tests", () => {
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
             axiosMock.onGet("/api/shift", { params: { id: 17 } }).timeout();
+            axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
         });
 
         const queryClient = new QueryClient();
@@ -74,6 +76,7 @@ describe("ShiftEditPage tests", () => {
             axiosMock.resetHistory();
             axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
             axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/drivers/all").reply(200, driverFixtures.threeDrivers);
             axiosMock.onGet("/api/shift", { params: { id: 17 } }).reply(200, {
                 id: 17,
                 day: "Tuesday",
@@ -125,8 +128,8 @@ describe("ShiftEditPage tests", () => {
             expect(dayField).toHaveValue("Tuesday");
             expect(startField).toHaveValue("05:00PM");
             expect(endField).toHaveValue("07:30PM");
-            expect(driverField).toHaveValue(1);
-            expect(backupDriverField).toHaveValue(2);
+            expect(driverField).toHaveValue("1");
+            expect(backupDriverField).toHaveValue("2");
         });
 
         test("Changes when you click Update", async () => {
@@ -152,16 +155,16 @@ describe("ShiftEditPage tests", () => {
             expect(dayField).toHaveValue("Tuesday");
             expect(startField).toHaveValue("05:00PM");
             expect(endField).toHaveValue("07:30PM");
-            expect(driverField).toHaveValue(1);
-            expect(backupDriverField).toHaveValue(2);
+            expect(driverField).toHaveValue("1");
+            expect(backupDriverField).toHaveValue("2");
 
             expect(submitButton).toBeInTheDocument();
         
             fireEvent.change(dayField, { target: { value: 'Monday' } });
             fireEvent.change(startField, { target: { value: '03:30PM' } });
             fireEvent.change(endField, { target: { value: "04:30PM" } });
-            fireEvent.change(driverField, { target: { value: 2 } });
-            fireEvent.change(backupDriverField, { target: { value: 3 } });
+            fireEvent.change(driverField, { target: { value: "2" } });
+            fireEvent.change(backupDriverField, { target: { value: "3" } });
         
             fireEvent.click(submitButton);
 


### PR DESCRIPTION
I added two dropdown lists for both driver ID and Backup driver ID in the shift create form such that admins don't have to remember all the driver id's and which corresponds to which person. Passes mutation and coverage testing with 100% on both. Used the driver controller API to retrieve all of the driver IDs. 

Acceptance criteria: When creating shifts, an admin can select the Driver ID and Backup Driver ID from a dropdown containing all of the drivers

Dokku deployment:  https://gauchoride-karstenlansing-dev.dokku-16.cs.ucsb.edu/

<img width="1396" alt="Screenshot 2024-05-23 at 12 09 31" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/43016839/9aabc44e-cc24-436e-a118-1ab6049494bf">
<img width="1396" alt="Screenshot 2024-05-23 at 12 09 55" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/43016839/8807fe73-f3fe-4b69-a2b3-d45f3bbccb0b">

Closes: [#13](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/issues/13)