### PR TITLE
AV-Created Feature for Swagger Navbar to Env Var Toggle

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -5,7 +5,8 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.datasource.initialization-mode=always

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -4,4 +4,4 @@ spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 
-app.showSwaggerUILink=false
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}


### PR DESCRIPTION
As a developer
I can easily turn on the swagger option on the app navbar for any deployment through defining an environment variable SHOW_SWAGGER_UI_LINK so that it is easy to access swagger when I need it, but I can easily turn it off when I don't.

Discussion
There is already code in the AppNavbar.js file that checks the value returned by /api/systemInfo for turning the Swagger link on and off. But, at the moment, the resource file isn't set up to pull that value from an environment variable.

Your job is just to make similar changes in this repo.

Acceptance Criteria
 When the config variable on dokku SHOW_SWAGGER_UI_LINK is set to true, the swagger link shows up
 When the config variable on dokku SHOW_SWAGGER_UI_LINK is set to false, the swagger link does NOT show up.
 
 Updated Behavior:
 
![Step 1](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/124840028/62ac9a24-c1d8-4fe7-a96a-7ab6aa475d89)
![Step 2](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/124840028/3ebacb41-f4bd-454b-8f71-0472a3322c90)

As seen from the clips above, the dokku originally shows the Swagger in the Navbar. Once I set the SHOW_SWAGGER_UI_LINK variable to false and rebuild the app, it will no longer show on the dokku's navbar when the site is relaunched.

https://gauchoride-therealandrxw-dev.dokku-16.cs.ucsb.edu/

Closes #16 