### PR TITLE
sp - FEATURE: Admin table should not move entries after a toggle button is pressed

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,16 +1,11 @@
 import OurTable, { ButtonColumn } from "main/components/OurTable"
 import { useBackendMutation } from "main/utils/useBackend";
-import React, { useState } from 'react'; // Added missing imports
+import React, { useState } from 'react'; 
 
 
 
 export default function UsersTable({ users}) {
-    // const [sortedUsers, setSortedUsers] = useState(users);
     const [sort, ] = useState({ keyToSort: 'id'});
-
-    // useEffect(() => {
-    //     setSortedUsers(sortTableById(users, sort));
-    // }, [users, sort]);
 
     function cellToAxiosParamsToggleRider(cell) {
         return {
@@ -74,10 +69,6 @@ export default function UsersTable({ users}) {
     );
     // Stryker enable all 
 
-    // function sortArray(array) {
-    //     return [...array].sort((a, b) => a.id - b.id);
-    // }
-
     function sortTableById(array, sort) {
         const {keyToSort} = sort;
             return [...array].sort((a, b) => a[keyToSort] - b[keyToSort]);
@@ -132,7 +123,6 @@ export default function UsersTable({ users}) {
         ButtonColumn("Toggle Rider", "danger", toggleRiderCallback, "UsersTable")
     ]
 
-    //const columnsToDisplay = showButtons ? buttonColumn : columns;
 
     return <OurTable
         data={sortTableById(users, sort)}

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -6,7 +6,7 @@ import React, { useState } from 'react'; // Added missing imports
 
 export default function UsersTable({ users}) {
     // const [sortedUsers, setSortedUsers] = useState(users);
-    const [sort, ] = useState({ keyToSort: 'id', direction: 'asc' });
+    const [sort, ] = useState({ keyToSort: 'id'});
 
     // useEffect(() => {
     //     setSortedUsers(sortTableById(users, sort));
@@ -79,10 +79,8 @@ export default function UsersTable({ users}) {
     // }
 
     function sortTableById(array, sort) {
-        const { keyToSort, direction } = sort;
-        if (direction === 'asc') {
+        const {keyToSort} = sort;
             return [...array].sort((a, b) => a[keyToSort] - b[keyToSort]);
-        }
     }
 
 

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -80,7 +80,7 @@ export default function UsersTable({ users}) {
 
     function sortTableById(array, sort) {
         const { keyToSort, direction } = sort;
-        if (direction == 'asc') {
+        if (direction === 'asc') {
             return [...array].sort((a, b) => a[keyToSort] - b[keyToSort]);
         }
     }

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,8 +1,17 @@
-
 import OurTable, { ButtonColumn } from "main/components/OurTable"
 import { useBackendMutation } from "main/utils/useBackend";
+import React, { useState } from 'react'; // Added missing imports
+
+
 
 export default function UsersTable({ users}) {
+    // const [sortedUsers, setSortedUsers] = useState(users);
+    const [sort, ] = useState({ keyToSort: 'id', direction: 'asc' });
+
+    // useEffect(() => {
+    //     setSortedUsers(sortTableById(users, sort));
+    // }, [users, sort]);
+
     function cellToAxiosParamsToggleRider(cell) {
         return {
             url: "/api/admin/users/toggleRider",
@@ -61,12 +70,27 @@ export default function UsersTable({ users}) {
     const toggleDriverMutation = useBackendMutation(
         cellToAxiosParamsToggleDriver,
         {},
-        ["/api/admin/users"]
+        ["/api/admin/users"],
     );
     // Stryker enable all 
 
+    // function sortArray(array) {
+    //     return [...array].sort((a, b) => a.id - b.id);
+    // }
+
+    function sortTableById(array, sort) {
+        const { keyToSort, direction } = sort;
+        if (direction == 'asc') {
+            return [...array].sort((a, b) => a[keyToSort] - b[keyToSort]);
+        }
+    }
+
+
     // Stryker disable next-line all : TODO try to make a good test for this
-    const toggleDriverCallback = async (cell) => { toggleDriverMutation.mutate(cell); }
+    const toggleDriverCallback = async (cell) => { 
+        await toggleDriverMutation.mutate(cell);
+        users = (sortTableById(users, sort)); // Sort after toggling driver
+    };
 
 
     const columns = [
@@ -113,7 +137,7 @@ export default function UsersTable({ users}) {
     //const columnsToDisplay = showButtons ? buttonColumn : columns;
 
     return <OurTable
-        data={users}
+        data={sortTableById(users, sort)}
         columns={buttonColumn}
         testid={"UsersTable"}
     />;

--- a/frontend/src/tests/components/Ride/RideTable.test.js
+++ b/frontend/src/tests/components/Ride/RideTable.test.js
@@ -293,5 +293,6 @@ describe("RideTable tests", () => {
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/ride/assigndriver/2'));
 
   });
+  
 
 });

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -1,11 +1,25 @@
-import { render } from "@testing-library/react";
+import React, { useState as useStateMock } from 'react';
+import { fireEvent, render, screen, act, waitFor} from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
-import UsersTable from "main/components/Users/UsersTable"
+import UsersTable, { sortArray } from "main/components/Users/UsersTable"
+
 import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+// jest.mock('react-router-dom', () => ({
+//     ...jest.requireActual('react-router-dom'),
+//     useNavigate: () => mockedNavigate
+// }));
 
 
 describe("UserTable tests", () => {
     const queryClient = new QueryClient();
+
+    jest.mock('react-router-dom', () => ({
+        ...jest.requireActual('react-router-dom'),
+        useNavigate: () => mockedNavigate
+    }));
 
     test("renders without crashing for empty table", () => {
         render(
@@ -54,5 +68,99 @@ describe("UserTable tests", () => {
         expect(getByTestId(`${testId}-cell-row-1-col-rider`)).toHaveTextContent("false");
         expect(getByTestId(`${testId}-cell-row-2-col-rider`)).toHaveTextContent("true");
       });
-});
+
+    test("Delete button calls delete callback", async () => {        
+        const { getByText, getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <UsersTable users={usersFixtures.threeUsers}/>
+            </QueryClientProvider>
+        );
+
+        const expectedHeaders = ["id", "First Name", "Last Name", "Email", "Admin", "Driver", "Rider"];
+        const expectedFields = ["id", "givenName", "familyName", "email", "admin", "driver","rider"];
+        const testId = "UsersTable";
+
+        expectedHeaders.forEach( (headerText)=> {
+            const header = getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach( (field)=> {
+          const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+          expect(header).toBeInTheDocument();
+        });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-0-col-driver`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-0-col-rider`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-1-col-driver`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-1-col-rider`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-2-col-rider`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        // Verify the element is present
+        const driverToggleButton = getByTestId('UsersTable-cell-row-0-col-Toggle Driver-button');
+        expect(driverToggleButton).toBeInTheDocument();
+
+
+        // Simulate a click event on the button
+        await act(async () => {
+            fireEvent.click(driverToggleButton);
+        });
+
+        expectedHeaders.forEach( (headerText)=> {
+            const header = getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach( (field)=> {
+          const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+          expect(header).toBeInTheDocument();
+        });
+
+        expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-0-col-driver`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-0-col-rider`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-1-col-driver`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-1-col-rider`)).toHaveTextContent("false");
+        expect(getByTestId(`${testId}-cell-row-2-col-rider`)).toHaveTextContent("true");
+        expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+      });
+
+        const sampleUsers = [
+            { id: 2, givenName: 'dkd', familyName: 'sdf', email: 'asdf@example.com', admin: true, driver: false, rider: false },
+            { id: 1, givenName: 'asdfa', familyName: 'asdfadsf', email: 'jane@example.com', admin: false, driver: true, rider: true },
+        ];
+    
+        test('initial state of sort should be { keyToSort: "id", direction: "asc" }', () => {
+            const { getByText, getByTestId } = render(
+                <QueryClientProvider client={queryClient}>
+                    <UsersTable users={sampleUsers}/>
+                </QueryClientProvider>
+            );
+
+            const expectedHeaders = ["id", "First Name", "Last Name", "Email", "Admin", "Driver", "Rider"];
+            const expectedFields = ["id", "givenName", "familyName", "email", "admin", "driver","rider"];
+            const testId = "UsersTable";
+
+            expectedHeaders.forEach( (headerText)=> {
+                const header = getByText(headerText);
+                expect(header).toBeInTheDocument();
+            });
+    
+            expectedFields.forEach( (field)=> {
+              const header = getByTestId(`${testId}-cell-row-0-col-${field}`);
+              expect(header).toBeInTheDocument();
+            });
+
+            expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+            expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        });
+    });
 

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -1,7 +1,7 @@
-import React, { useState as useStateMock } from 'react';
-import { fireEvent, render, screen, act, waitFor} from "@testing-library/react";
+import React from 'react';
+import { fireEvent, render, act} from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
-import UsersTable, { sortArray } from "main/components/Users/UsersTable"
+import UsersTable from "main/components/Users/UsersTable"
 
 import { QueryClient, QueryClientProvider } from "react-query";
 

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -7,11 +7,6 @@ import { QueryClient, QueryClientProvider } from "react-query";
 
 const mockedNavigate = jest.fn();
 
-// jest.mock('react-router-dom', () => ({
-//     ...jest.requireActual('react-router-dom'),
-//     useNavigate: () => mockedNavigate
-// }));
-
 
 describe("UserTable tests", () => {
     const queryClient = new QueryClient();
@@ -101,12 +96,10 @@ describe("UserTable tests", () => {
         expect(getByTestId(`${testId}-cell-row-2-col-rider`)).toHaveTextContent("true");
         expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
 
-        // Verify the element is present
         const driverToggleButton = getByTestId('UsersTable-cell-row-0-col-Toggle Driver-button');
         expect(driverToggleButton).toBeInTheDocument();
 
 
-        // Simulate a click event on the button
         await act(async () => {
             fireEvent.click(driverToggleButton);
         });

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -135,7 +135,10 @@ describe("UserTable tests", () => {
 
         const sampleUsers = [
             { id: 2, givenName: 'dkd', familyName: 'sdf', email: 'asdf@example.com', admin: true, driver: false, rider: false },
-            { id: 1, givenName: 'asdfa', familyName: 'asdfadsf', email: 'jane@example.com', admin: false, driver: true, rider: true },
+            { id: 4, givenName: 'asdfa', familyName: 'asdfadsf', email: 'jane@example.com', admin: false, driver: true, rider: true },
+            { id: 3, givenName: 'asd12321fa', familyName: 'asdfadsf', email: 'jane@example.com', admin: false, driver: true, rider: true },
+            { id: 1, givenName: 'asd34324fa', familyName: 'asdfadsf', email: 'jane@example.com', admin: false, driver: true, rider: true },
+
         ];
     
         test('initial state of sort should be { keyToSort: "id", direction: "asc" }', () => {
@@ -160,7 +163,15 @@ describe("UserTable tests", () => {
             });
 
             expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+            expect(getByTestId(`${testId}-cell-row-0-col-givenName`)).toHaveTextContent("asd34324fa");
             expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+            expect(getByTestId(`${testId}-cell-row-1-col-givenName`)).toHaveTextContent("dkd");
+
+            expect(getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+            expect(getByTestId(`${testId}-cell-row-2-col-givenName`)).toHaveTextContent("asd12321fa");
+            expect(getByTestId(`${testId}-cell-row-3-col-id`)).toHaveTextContent("4");
+            expect(getByTestId(`${testId}-cell-row-3-col-givenName`)).toHaveTextContent("asdfa");
+
         });
     });
 


### PR DESCRIPTION
I sorted the users table based on id. It the ordering of the  not move after admin pressing driver toggle button. 

+  User table is sorted by some metric
+ When a property of a user is toggled, they should remain in the same position in the table (instead of moving to the bottom)

![image](https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/122487506/1477db7a-87b9-434f-a16f-131f7455e7e0)


dokku deployment:
      https://final-spark686-sort.dokku-16.cs.ucsb.edu

Closes #15 