### PR TITLE
hs- Standardize Header Capitalization Across ShiftTable

### DIFF
--- a/frontend/src/main/components/Shift/ShiftTable.js
+++ b/frontend/src/main/components/Shift/ShiftTable.js
@@ -44,11 +44,11 @@ export default function ShiftTable({
             accessor: 'day',
         },
         {
-            Header: 'Shift start',
+            Header: 'Shift Start',
             accessor: 'shiftStart',
         },
         {
-            Header: 'Shift end',
+            Header: 'Shift End',
             accessor: 'shiftEnd',
         },
         {
@@ -60,7 +60,7 @@ export default function ShiftTable({
               ),
         },
         {
-            Header: 'Backup driver',
+            Header: 'Backup Driver',
             accessor: 'driverBackupID',
             Cell: ({ value }) => (
                 // Stryker disable next-line all : hard to set up test

--- a/frontend/src/tests/components/Shift/ShiftTable.test.js
+++ b/frontend/src/tests/components/Shift/ShiftTable.test.js
@@ -13,7 +13,7 @@ jest.mock('react-router-dom', () => ({
 
 const mockedNavigate = jest.fn();
 
-const expectedHeaders = ["id", "Day", "Shift start", "Shift end", "Driver", "Backup driver"];
+const expectedHeaders = ["id", "Day", "Shift Start", "Shift End", "Driver", "Backup Driver"];
 const expectedFields = ["id", "day", "shiftStart", "shiftEnd", "driverID", "driverBackupID"];
 const testId = "ShiftTable";
 describe("ShiftTable tests", () => {


### PR DESCRIPTION
This PR introduces changes to the ShiftTable.js and ShiftTable.test.js files to standardize the capitalization of all headers. The changes ensure that every header on the Shifts page, accessible by both drivers and admins, uses title case.
deployed on dokku: http://gauchoride-hannahshakouri01-dev.dokku-16.cs.ucsb.edu

before changes: 
<img width="1178" alt="Screenshot 2024-05-29 at 12 14 48 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/97555072/6aacfd79-532a-48bf-a2e3-ddd5e02d67aa">

after changes: 
<img width="1179" alt="Screenshot 2024-05-29 at 12 14 07 PM" src="https://github.com/ucsb-cs156-s24/proj-gauchoride-s24-5pm-8/assets/97555072/e74af67a-c712-416c-8e5c-c927bc8600b5">


Closes #6 